### PR TITLE
Fix for #31, #34, #35 and #36

### DIFF
--- a/src/Binaron.Serializer.Tests/CustomTestCollection.cs
+++ b/src/Binaron.Serializer.Tests/CustomTestCollection.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Binaron.Serializer.Tests
+{
+    public class CustomTestCollection<T> : IEnumerable<T>
+    {
+        private List<T> List = new List<T>();
+
+        public T this[int index] => List[index];
+
+        public int Count => List.Count;
+
+        public void Add(T value) => List.Add(value);
+
+
+        public IEnumerator<T> GetEnumerator() => List.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => List.GetEnumerator();
+
+        public class TestCollectionObject
+        {
+            public T A { get; set; }
+
+            public TestCollectionObject()
+            {
+            }
+
+            public TestCollectionObject(T a)
+            {
+                A = a;
+            }
+        }
+    }
+}

--- a/src/Binaron.Serializer.Tests/ListSerializationTests.cs
+++ b/src/Binaron.Serializer.Tests/ListSerializationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -263,6 +263,116 @@ namespace Binaron.Serializer.Tests
                     return Tester.GetEnumerable(enumerable.Concat(item).ToArray()) as TList;
                 default:
                     throw new NotSupportedException();
+            }
+        }
+
+        [Test]
+        public void CustomCollectionIntTest()
+        {
+            CustomTestCollection<int> collection = new CustomTestCollection<int>()
+            {
+                0, 1, 2, 3, 4
+            };
+
+            var dest = Tester.TestRoundTrip<CustomTestCollection<int>>(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0]);
+            Assert.AreEqual(1, dest[1]);
+            Assert.AreEqual(2, dest[2]);
+            Assert.AreEqual(3, dest[3]);
+            Assert.AreEqual(4, dest[4]);
+        }
+
+        [TestCaseSource(typeof(AllTestCases), nameof(AllTestCases.TestCaseOfValues))]
+        public void CustomCollectionOfTypeTest<TSource>(TSource v)
+        {
+            CustomTestCollection<TSource> collection = new CustomTestCollection<TSource>()
+            {
+                v
+            };
+
+            var dest = Tester.TestRoundTrip<CustomTestCollection<TSource>>(collection);
+            Assert.AreEqual(1, dest.Count);
+            Assert.AreEqual(v, dest[0]);
+        }
+
+
+        [Test]
+        public void CustomCollectionObjectTest()
+        {
+            CustomTestCollection<CustomTestCollection<int>.TestCollectionObject> collection = new CustomTestCollection<CustomTestCollection<int>.TestCollectionObject>()
+            {
+                new CustomTestCollection<int>.TestCollectionObject(0),
+                new CustomTestCollection<int>.TestCollectionObject(1),
+                new CustomTestCollection<int>.TestCollectionObject(2),
+                new CustomTestCollection<int>.TestCollectionObject(3),
+                new CustomTestCollection<int>.TestCollectionObject(4),
+            };
+
+            var dest = Tester.TestRoundTrip(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0].A);
+            Assert.AreEqual(1, dest[1].A);
+            Assert.AreEqual(2, dest[2].A);
+            Assert.AreEqual(3, dest[3].A);
+            Assert.AreEqual(4, dest[4].A);
+        }
+
+        [Test]
+        public void TestListWithNullInside()
+        {
+            CustomTestCollection<CustomTestCollection<int>.TestCollectionObject> collection = new CustomTestCollection<CustomTestCollection<int>.TestCollectionObject>()
+            {
+                new CustomTestCollection<int>.TestCollectionObject(0),
+                new CustomTestCollection<int>.TestCollectionObject(1),
+                null,
+                new CustomTestCollection<int>.TestCollectionObject(3),
+                new CustomTestCollection<int>.TestCollectionObject(4),
+            };
+
+            var dest = Tester.TestRoundTrip(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0].A);
+            Assert.AreEqual(1, dest[1].A);
+            Assert.AreEqual(null, dest[2]);
+            Assert.AreEqual(3, dest[3].A);
+            Assert.AreEqual(4, dest[4].A);
+        }
+
+        [Test]
+        public void TestListOfNullables1()
+        {
+            var collection = new CustomTestCollection<int?>() { 1, null, 2 };
+            using (var ms1 = new MemoryStream())
+            {
+                var so = new SerializerOptions();
+                BinaronConvert.Serialize(collection, ms1, so);
+                using (var ms2 = new MemoryStream(ms1.ToArray()))
+                {
+                    var cr2 = BinaronConvert.Deserialize<CustomTestCollection<int?>>(ms2);
+                    Assert.AreEqual(3, cr2.Count);
+                    Assert.AreEqual(1, cr2[0]);
+                    Assert.AreEqual(null, cr2[1]);
+                    Assert.AreEqual(2, cr2[2]);
+                }
+            }
+        }
+        [Test]
+        public void TestListOfNullables2()
+        {
+            var collection = new List<int?>() { 1, null, 2 };
+            using (var ms1 = new MemoryStream())
+            {
+                var so = new SerializerOptions();
+                BinaronConvert.Serialize(collection, ms1, so);
+                using (var ms2 = new MemoryStream(ms1.ToArray()))
+                {
+                    var cr2 = BinaronConvert.Deserialize<List<int?>>(ms2);
+                    Assert.AreEqual(3, cr2.Count);
+                    Assert.AreEqual(1, cr2[0]);
+                    Assert.AreEqual(null, cr2[1]);
+                    Assert.AreEqual(2, cr2[2]);
+                }
             }
         }
     }

--- a/src/Binaron.Serializer.Tests/MemberGetSetterTests.cs
+++ b/src/Binaron.Serializer.Tests/MemberGetSetterTests.cs
@@ -49,5 +49,6 @@ namespace Binaron.Serializer.Tests
                 set { }
             }
         }
+       
     }
 }

--- a/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
+++ b/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
@@ -394,6 +394,68 @@ namespace Binaron.Serializer.Tests
             }
         }
 
+        [TestCase(1)]
+        [TestCase(null)]
+        public void NullableTest1(int? value)
+        {
+            using (var ms1 = new MemoryStream())
+            {
+                BinaronConvert.Serialize<int?>(value, ms1);
+                using (var ms2 = new MemoryStream(ms1.ToArray()))
+                {
+                    Assert.AreEqual(value, BinaronConvert.Deserialize<int?>(ms2));
+                    
+                }
+            }
+        }
+
+        [TestCase(1, "a")]
+        [TestCase(null, null)]
+        [TestCase(1, null)]
+        [TestCase(null, "abcd")]
+
+        public void MemberSetterNullableType1(int? v1, string v2)
+        {
+            TestClass1 tc1 = new TestClass1() { IntValue = v1, StringValue = v2 };
+            using (MemoryStream ms = new MemoryStream())
+            {
+                BinaronConvert.Serialize(tc1, ms);
+                using (MemoryStream ms1 = new MemoryStream(ms.ToArray()))
+                {
+                    var tc2 = BinaronConvert.Deserialize<TestClass1>(ms1);
+                    Assert.AreEqual(v1, tc2.IntValue);
+                    Assert.AreEqual(v2, tc2.StringValue);
+                }
+            }
+        }
+
+        [TestCase(1, "a")]
+        [TestCase(null, null)]
+        [TestCase(1, null)]
+        [TestCase(null, "abcd")]
+
+        public void MemberSetterNullableType2(int? v1, string v2)
+        {
+            List<TestClass1> tc1 = new List<TestClass1>() { new TestClass1() { IntValue = v1, StringValue = v2 } };
+            using (MemoryStream ms = new MemoryStream())
+            {
+                BinaronConvert.Serialize(tc1, ms);
+                using (MemoryStream ms1 = new MemoryStream(ms.ToArray()))
+                {
+                    var tc2 = BinaronConvert.Deserialize<List<TestClass1>>(ms1);
+                    Assert.AreEqual(1, tc2.Count);
+                    Assert.AreEqual(v1, tc2[0].IntValue);
+                    Assert.AreEqual(v2, tc2[0].StringValue);
+                }
+            }
+        }
+
+        private class TestClass1
+        {
+            public int? IntValue { get; set; }
+            public string StringValue { get; set; }
+        }
+
         private class TestClass<T>
         {
             public DateTime RootValue { get; set; }

--- a/src/Binaron.Serializer/Infrastructure/EnumerableWrapperWithAdd.cs
+++ b/src/Binaron.Serializer/Infrastructure/EnumerableWrapperWithAdd.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace Binaron.Serializer.Infrastructure
+{
+    internal class EnumerableWrapperWithAdd<T>
+    {
+        private readonly Action<object, T> Action;
+        private readonly object Result;
+        public bool HasAddAction { get; private set; } = false;
+
+        public EnumerableWrapperWithAdd(IEnumerable<T> result)
+        {
+            Result = result;
+            var method = result.GetType().GetMethod("Add", new Type[] { typeof(T) });
+
+            if (method == null)
+                Action = (o, v) => { };
+            else
+            {
+                HasAddAction = true;
+                DynamicMethod action = new DynamicMethod(
+                            "Add",
+                            null,
+                            new Type[] { typeof(object), typeof(T) },
+                            this.GetType().Module);
+
+                var il = action.GetILGenerator();
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(method.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, method);
+                il.Emit(OpCodes.Ret);
+
+                Action = (Action<object, T>)action.CreateDelegate(typeof(Action<object, T>));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(T value)
+        {
+            Action(Result, value);
+        }
+    }
+}

--- a/src/Binaron.Serializer/Infrastructure/GenericReader.cs
+++ b/src/Binaron.Serializer/Infrastructure/GenericReader.cs
@@ -45,293 +45,514 @@ namespace Binaron.Serializer.Infrastructure
             switch (TypeOf<TElement>.TypeCode)
             {
                 case TypeCode.Object:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<TElement> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<TElement> l)
                         {
-                            var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
-                            l.Add((TElement) v);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                l.Add((TElement)v);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<TElement> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<TElement>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                l1.Add((TElement)v);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Boolean:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<bool> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Bool)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<bool> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadBool(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Bool)
                             {
-                                var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadBool(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<bool> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<bool>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Bool)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadBool(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Byte:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<byte> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Byte)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<byte> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadByte(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Byte)
                             {
-                                var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadByte(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
                         }
+                        else if (result is IEnumerable<byte> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<byte>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Byte)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadByte(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                            return result;
+                        }
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Char:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<char> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Char)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<char> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadChar(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Char)
                             {
-                                var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadChar(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<char> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<char>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Char)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadChar(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.DateTime:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<DateTime> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.DateTime)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<DateTime> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadDateTime(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.DateTime)
                             {
-                                var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadDateTime(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<DateTime> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<DateTime>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.DateTime)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadDateTime(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Guid:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<Guid> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Guid)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<Guid> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadGuid(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Guid)
                             {
-                                var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadGuid(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<Guid> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<Guid>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Guid)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadGuid(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Decimal:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<decimal> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Decimal)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<decimal> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadDecimal(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Decimal)
                             {
-                                var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadDecimal(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<decimal> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<decimal>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Decimal)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadDecimal(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Double:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<double> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Double)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<double> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadDouble(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Double)
                             {
-                                var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadDouble(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<double> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<double>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Double)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadDouble(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int16:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<short> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Short)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<short> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadShort(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Short)
                             {
-                                var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadShort(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<short> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<short>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Short)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadShort(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int32:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<int> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Int)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<int> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadInt(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Int)
                             {
-                                var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadInt(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<int> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<int>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Int)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadInt(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int64:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<long> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Long)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<long> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadLong(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Long)
                             {
-                                var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadLong(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<long> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<long>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Long)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadLong(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.SByte:
                 {
                     var result = CreateResultObject<T, TElement>();
@@ -355,144 +576,271 @@ namespace Binaron.Serializer.Infrastructure
 
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
+                    else if (result is IEnumerable<sbyte> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<sbyte>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.SByte)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadSByte(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
 
-                    Discarder.Discard(reader);
+                            return result;
+                        }
+
+                        Discarder.Discard(reader);
                     return result;
                 }
                 case TypeCode.Single:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<float> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.Float)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<float> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadFloat(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Float)
                             {
-                                var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadFloat(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<float> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<float>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Float)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadFloat(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.String:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<string> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.String)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<string> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadString(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.String)
                             {
-                                var v = SelfUpgradingReader.ReadAsString(reader, valueType);
-                                l.Add(v);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadString(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                    l.Add(v);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<string> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<string>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.String)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadString(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                    l1.Add(v);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.UInt16:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<ushort> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.UShort)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<ushort> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadUShort(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UShort)
                             {
-                                var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadUShort(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<ushort> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<ushort>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UShort)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadUShort(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.UInt32:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<uint> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.UInt)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<uint> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadUInt(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UInt)
                             {
-                                var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadUInt(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<uint> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<uint>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UInt)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadUInt(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.UInt64:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<ulong> l)
                     {
-                        var valueType = Reader.ReadSerializedType(reader);
-                        if (valueType == SerializedType.ULong)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<ulong> l)
                         {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
-                                l.Add(Reader.ReadULong(reader));
-                        }
-                        else
-                        {
-                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.ULong)
                             {
-                                var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
-                                if (v.HasValue)
-                                    l.Add(v.Value);
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l.Add(Reader.ReadULong(reader));
                             }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                    if (v.HasValue)
+                                        l.Add(v.Value);
+                                }
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+
+                        }
+                        else if (result is IEnumerable<ulong> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<ulong>(e1);
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.ULong)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    l1.Add(Reader.ReadULong(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                    if (v.HasValue)
+                                        l1.Add(v.Value);
+                                }
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
-                    }
 
-                    Discarder.Discard(reader);
-                    return result;
-                }
+                        Discarder.Discard(reader);
+                        return result;
+                    }
             }
 
             return null;
@@ -503,61 +851,99 @@ namespace Binaron.Serializer.Infrastructure
             switch (TypeOf<TElement>.TypeCode)
             {
                 case TypeCode.Object:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<TElement> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<TElement> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
-                            l.Add((TElement) v);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                l.Add((TElement)v);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<TElement> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<TElement>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                l1.Add((TElement)v);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Boolean:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<bool> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<bool> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<bool> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<bool>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Byte:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<byte> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<byte> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<byte> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<byte>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Char:
                 {
                     var result = CreateResultObject<T, TElement>();
@@ -573,124 +959,215 @@ namespace Binaron.Serializer.Infrastructure
 
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
+                    else if (result is IEnumerable<char> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<char>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
 
-                    Discarder.Discard(reader);
+                            return result;
+                        }
+
+                        Discarder.Discard(reader);
                     return result;
                 }
                 case TypeCode.DateTime:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<DateTime> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<DateTime> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<DateTime> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<DateTime>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Guid:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<Guid> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<Guid> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<Guid> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<Guid>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Decimal:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<decimal> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<decimal> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<decimal> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<decimal>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Double:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<double> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<double> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<double> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<double>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int16:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<short> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<short> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<short> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<short>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int32:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<int> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<int> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<int> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<int>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Int64:
                 {
                     var result = CreateResultObject<T, TElement>();
@@ -706,85 +1183,149 @@ namespace Binaron.Serializer.Infrastructure
 
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
+                    else if (result is IEnumerable<long> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<long>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
 
-                    Discarder.Discard(reader);
+                            return result;
+                        }
+
+                        Discarder.Discard(reader);
                     return result;
                 }
                 case TypeCode.SByte:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<sbyte> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<sbyte> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<sbyte> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<sbyte>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.Single:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<float> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<float> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<float> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<float>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.String:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<string> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<string> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsString(reader, valueType);
-                            l.Add(v);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                l.Add(v);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<string> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<string>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                l1.Add(v);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.UInt16:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<ushort> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<ushort> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<ushort> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<ushort>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
                 case TypeCode.UInt32:
                 {
                     var result = CreateResultObject<T, TElement>();
@@ -800,29 +1341,55 @@ namespace Binaron.Serializer.Infrastructure
 
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
+                    else if (result is IEnumerable<uint> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<uint>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
 
-                    Discarder.Discard(reader);
+                            return result;
+                        }
+
+                        Discarder.Discard(reader);
                     return result;
                 }
                 case TypeCode.UInt64:
-                {
-                    var result = CreateResultObject<T, TElement>();
-                    if (result is ICollection<ulong> l)
                     {
-                        while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                        var result = CreateResultObject<T, TElement>();
+                        if (result is ICollection<ulong> l)
                         {
-                            var valueType = Reader.ReadSerializedType(reader);
-                            var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
-                            if (v.HasValue)
-                                l.Add(v.Value);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                if (v.HasValue)
+                                    l.Add(v.Value);
+                            }
+
+                            return typeof(T).IsArray ? ToArray(l) : result;
+                        }
+                        else if (result is IEnumerable<ulong> e1)
+                        {
+                            var l1 = new EnumerableWrapperWithAdd<ulong>(e1);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                if (v.HasValue)
+                                    l1.Add(v.Value);
+                            }
+
+                            return result;
                         }
 
-                        return typeof(T).IsArray ? ToArray(l) : result;
+                        Discarder.Discard(reader);
+                        return result;
                     }
-
-                    Discarder.Discard(reader);
-                    return result;
-                }
             }
 
             return null;
@@ -922,8 +1489,36 @@ namespace Binaron.Serializer.Infrastructure
         {
             public static (bool Success, object Result) AddEnums<T>(ReaderState reader, object list, bool convertToArray) where T : struct
             {
-                if (!(list is ICollection<T> l)) 
-                    return (false, list);
+                if (!(list is ICollection<T> l))
+                {
+                    if (!(list is IEnumerable<T> e))
+                        return (false, list);
+
+                    EnumerableWrapperWithAdd<T> adder = new EnumerableWrapperWithAdd<T>(e);
+                    if (!adder.HasAddAction)
+                        return (false, list);
+
+                    do
+                    {
+                        try
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var val = ReadEnum<T>(reader);
+                                if (val.HasValue)
+                                    adder.Add(val.Value);
+                            }
+                            break;
+                        }
+                        catch (InvalidCastException)
+                        {
+                        }
+                        catch (OverflowException)
+                        {
+                        }
+                    } while (true);
+                    return (true, list);
+                }
 
                 do
                 {

--- a/src/Binaron.Serializer/Infrastructure/GenericWriter.cs
+++ b/src/Binaron.Serializer/Infrastructure/GenericWriter.cs
@@ -40,7 +40,7 @@ namespace Binaron.Serializer.Infrastructure
                     foreach (var item in (IEnumerable<T>) list)
                     {
                         writer.Write((byte) EnumerableType.HasItem);
-                        Serializer.WriteNonPrimitive(writer, item);
+                        Serializer.WriteValue(writer, item);
                     }
                     writer.Write((byte) EnumerableType.End);
                 }
@@ -312,8 +312,18 @@ namespace Binaron.Serializer.Infrastructure
             {
                 public void Write(WriterState writer, ICollection list)
                 {
-                    foreach (var item in (ICollection<T>) list)
-                        Serializer.WriteNonPrimitive(writer, item);
+                    var type = typeof(T);
+                    var type1 = Nullable.GetUnderlyingType(type);
+                    if (type1 != null && type1 != type)
+                    {
+                        foreach (var item in (ICollection<T>)list)
+                            Serializer.WriteValue(writer, item);
+                    }
+                    else
+                    {
+                        foreach (var item in (ICollection<T>)list)
+                            Serializer.WriteNonPrimitive(writer, item);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Motivation:

#31

The library is able to serialize but not able to restore classes that support `IEnumerable<T>` and has `Add(T value)` method (e.g. class good enough to use C# `var collection = new Collection<int>() { 1, 2, 3, 4 }` declaration). 

Fix: 

1) Original code that restores the collection is `ICollection<T>` is left intact (because it is fast)

2) For each location where `ICollection<T>` is expected, another branch expecting `IEnumerable<T>` is added. The implementation uses code emit to access the `Add` method of the target object. This option is 4-8x times slower than `ICollection ` (but before the library didn't deserialize it at all)

Note: Comparing the previous pull request the implementation is changed. Now instead of caching the action in the dictionary, the action (the class containing the action) is created and kept in the local variable. It is marginally faster (less than 10%) than the `ConcurrentDictionary` approach used before but offers a more straightforward solution.

#34, #35 and #36

Motivation: 

1) The library threw `NullPointerException` during an attempt to save of a `null` value of a `Nullable` type. 

Cause: The code didn't expect to receive `null` in the method. 

Fix: I've added writing the code of null value to stream in this case. 

2) The `null` was restored as `default(T)` for `Nullable<T>` (e.g. as `0` for `int?`).

Cause: The code saved `int?` values as `object` and tried to restore them using a parameterless constructor (and, expectedly, has no setters for a read-only `Nullable<T>.Value` property). 

Fix: The code now saves `Nullable(T)` either as `null` or as a value of `T` type. 

Fix: Handling cases for nullable types is added to serialization and deserialization of the values and 

Note: I checked, my changes didn't affect performance (at least within two digits after the decimal point as Benchmark application prints) 
