### PR TITLE
Fix nullables and add support for IEnumerable with Add method

### DIFF
--- a/src/Binaron.Serializer.Tests/CustomTestCollection.cs
+++ b/src/Binaron.Serializer.Tests/CustomTestCollection.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Binaron.Serializer.Tests
+{
+    public class CustomTestCollection<T> : IEnumerable<T>
+    {
+        private List<T> List = new List<T>();
+
+        public T this[int index] => List[index];
+
+        public int Count => List.Count;
+
+        public void Add(T value) => List.Add(value);
+
+
+        public IEnumerator<T> GetEnumerator() => List.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => List.GetEnumerator();
+
+        public class TestCollectionObject
+        {
+            public T A { get; set; }
+
+            public TestCollectionObject()
+            {
+            }
+
+            public TestCollectionObject(T a)
+            {
+                A = a;
+            }
+        }
+    }
+}

--- a/src/Binaron.Serializer.Tests/ListSerializationTests.cs
+++ b/src/Binaron.Serializer.Tests/ListSerializationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -263,6 +263,116 @@ namespace Binaron.Serializer.Tests
                     return Tester.GetEnumerable(enumerable.Concat(item).ToArray()) as TList;
                 default:
                     throw new NotSupportedException();
+            }
+        }
+
+        [Test]
+        public void CustomCollectionIntTest()
+        {
+            CustomTestCollection<int> collection = new CustomTestCollection<int>()
+            {
+                0, 1, 2, 3, 4
+            };
+
+            var dest = Tester.TestRoundTrip<CustomTestCollection<int>>(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0]);
+            Assert.AreEqual(1, dest[1]);
+            Assert.AreEqual(2, dest[2]);
+            Assert.AreEqual(3, dest[3]);
+            Assert.AreEqual(4, dest[4]);
+        }
+
+        [TestCaseSource(typeof(AllTestCases), nameof(AllTestCases.TestCaseOfValues))]
+        public void CustomCollectionOfTypeTest<TSource>(TSource v)
+        {
+            CustomTestCollection<TSource> collection = new CustomTestCollection<TSource>()
+            {
+                v
+            };
+
+            var dest = Tester.TestRoundTrip<CustomTestCollection<TSource>>(collection);
+            Assert.AreEqual(1, dest.Count);
+            Assert.AreEqual(v, dest[0]);
+        }
+
+
+        [Test]
+        public void CustomCollectionObjectTest()
+        {
+            CustomTestCollection<CustomTestCollection<int>.TestCollectionObject> collection = new CustomTestCollection<CustomTestCollection<int>.TestCollectionObject>()
+            {
+                new CustomTestCollection<int>.TestCollectionObject(0),
+                new CustomTestCollection<int>.TestCollectionObject(1),
+                new CustomTestCollection<int>.TestCollectionObject(2),
+                new CustomTestCollection<int>.TestCollectionObject(3),
+                new CustomTestCollection<int>.TestCollectionObject(4),
+            };
+
+            var dest = Tester.TestRoundTrip(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0].A);
+            Assert.AreEqual(1, dest[1].A);
+            Assert.AreEqual(2, dest[2].A);
+            Assert.AreEqual(3, dest[3].A);
+            Assert.AreEqual(4, dest[4].A);
+        }
+
+        [Test]
+        public void TestListWithNullInside()
+        {
+            CustomTestCollection<CustomTestCollection<int>.TestCollectionObject> collection = new CustomTestCollection<CustomTestCollection<int>.TestCollectionObject>()
+            {
+                new CustomTestCollection<int>.TestCollectionObject(0),
+                new CustomTestCollection<int>.TestCollectionObject(1),
+                null,
+                new CustomTestCollection<int>.TestCollectionObject(3),
+                new CustomTestCollection<int>.TestCollectionObject(4),
+            };
+
+            var dest = Tester.TestRoundTrip(collection);
+            Assert.AreEqual(5, dest.Count);
+            Assert.AreEqual(0, dest[0].A);
+            Assert.AreEqual(1, dest[1].A);
+            Assert.AreEqual(null, dest[2]);
+            Assert.AreEqual(3, dest[3].A);
+            Assert.AreEqual(4, dest[4].A);
+        }
+
+        [Test]
+        public void TestListOfNullables1()
+        {
+            var collection = new CustomTestCollection<int?>() { 1, null, 2 };
+            using (var ms1 = new MemoryStream())
+            {
+                var so = new SerializerOptions();
+                BinaronConvert.Serialize(collection, ms1, so);
+                using (var ms2 = new MemoryStream(ms1.ToArray()))
+                {
+                    var cr2 = BinaronConvert.Deserialize<CustomTestCollection<int?>>(ms2);
+                    Assert.AreEqual(3, cr2.Count);
+                    Assert.AreEqual(1, cr2[0]);
+                    Assert.AreEqual(null, cr2[1]);
+                    Assert.AreEqual(2, cr2[2]);
+                }
+            }
+        }
+        [Test]
+        public void TestListOfNullables2()
+        {
+            var collection = new List<int?>() { 1, null, 2 };
+            using (var ms1 = new MemoryStream())
+            {
+                var so = new SerializerOptions();
+                BinaronConvert.Serialize(collection, ms1, so);
+                using (var ms2 = new MemoryStream(ms1.ToArray()))
+                {
+                    var cr2 = BinaronConvert.Deserialize<List<int?>>(ms2);
+                    Assert.AreEqual(3, cr2.Count);
+                    Assert.AreEqual(1, cr2[0]);
+                    Assert.AreEqual(null, cr2[1]);
+                    Assert.AreEqual(2, cr2[2]);
+                }
             }
         }
     }

--- a/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
+++ b/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
@@ -394,6 +394,53 @@ namespace Binaron.Serializer.Tests
             }
         }
 
+        [TestCase(1)]
+        [TestCase(null)]
+        public void NullableTest1(int? value)
+        {
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(value, stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            Assert.AreEqual(value, BinaronConvert.Deserialize<int?>(stream));
+        }
+
+        [TestCase(1, "a")]
+        [TestCase(null, null)]
+        [TestCase(1, null)]
+        [TestCase(null, "abcd")]
+        public void MemberSetterNullableType1(int? v1, string v2)
+        {
+            var tc1 = new TestClass1 { IntValue = v1, StringValue = v2 };
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(tc1, stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var tc2 = BinaronConvert.Deserialize<TestClass1>(stream);
+            Assert.AreEqual(v1, tc2.IntValue);
+            Assert.AreEqual(v2, tc2.StringValue);
+        }
+
+        [TestCase(1, "a")]
+        [TestCase(null, null)]
+        [TestCase(1, null)]
+        [TestCase(null, "abcd")]
+        public void MemberSetterNullableType2(int? v1, string v2)
+        {
+            var tc1 = new List<TestClass1> { new() { IntValue = v1, StringValue = v2 } };
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(tc1, stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var tc2 = BinaronConvert.Deserialize<List<TestClass1>>(stream);
+            Assert.AreEqual(1, tc2.Count);
+            Assert.AreEqual(v1, tc2[0].IntValue);
+            Assert.AreEqual(v2, tc2[0].StringValue);
+        }
+
+        private class TestClass1
+        {
+            public int? IntValue { get; set; }
+            public string StringValue { get; set; }
+        }
+
         private class TestClass<T>
         {
             public DateTime RootValue { get; set; }

--- a/src/Binaron.Serializer/Accessors/GetterHandler.cs
+++ b/src/Binaron.Serializer/Accessors/GetterHandler.cs
@@ -15,7 +15,7 @@ namespace Binaron.Serializer.Accessors
         private static readonly ConcurrentDictionary<Type, IMemberGetterHandler<WriterState>[]> MemberGetters = new ConcurrentDictionary<Type, IMemberGetterHandler<WriterState>[]>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IMemberGetterHandler<WriterState>[] GetGetterHandlers(Type type) => MemberGetters.GetOrAdd(type, _ => CreateGetters(type));
+        public static IMemberGetterHandler<WriterState>[] GetGetterHandlers(Type type) => MemberGetters.GetOrAdd(type, CreateGetters);
 
         public static class GetterHandlers<T>
         {

--- a/src/Binaron.Serializer/Accessors/SetterHandler.cs
+++ b/src/Binaron.Serializer/Accessors/SetterHandler.cs
@@ -24,7 +24,7 @@ namespace Binaron.Serializer.Accessors
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (Func<object> Activate, IDictionary<string, IMemberSetterHandler<ReaderState>> Setters, Type IDictionaryValueType, Type ActualType) GetActivatorAndSetterHandlers(Type type) => 
-            ActivatorsAndSetters.GetOrAdd(type, _ => CreateActivatorsAndSetters(type));
+            ActivatorsAndSetters.GetOrAdd(type, CreateActivatorsAndSetters);
 
         private static (Func<object>, IDictionary<string, IMemberSetterHandler<ReaderState>>, Type IDictionaryValueType, Type ActualType) CreateActivatorsAndSetters(Type type)
         {
@@ -37,7 +37,7 @@ namespace Binaron.Serializer.Accessors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IDictionary<string, IMemberSetterHandler<ReaderState>> GetSetterHandlers(Type type) => SetterHandlers.GetOrAdd(type, _ => CreateSetters(type));
+        public static IDictionary<string, IMemberSetterHandler<ReaderState>> GetSetterHandlers(Type type) => SetterHandlers.GetOrAdd(type, CreateSetters);
 
         private static Func<object> CreateActivator(Type type) => Activator.Get(type);
 

--- a/src/Binaron.Serializer/Creators/Activator.cs
+++ b/src/Binaron.Serializer/Creators/Activator.cs
@@ -11,9 +11,9 @@ namespace Binaron.Serializer.Creators
         private static readonly ConcurrentDictionary<Type, Func<int, object>> WithCapacityActivators = new ConcurrentDictionary<Type, Func<int, object>>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Func<object> Get(Type type) => Activators.GetOrAdd(type, _ => CreateActivator(type));
+        public static Func<object> Get(Type type) => Activators.GetOrAdd(type, CreateActivator);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Func<int, object> GetWithCapacity(Type type) => WithCapacityActivators.GetOrAdd(type, _ => CreateWithCapacityActivator(type));
+        public static Func<int, object> GetWithCapacity(Type type) => WithCapacityActivators.GetOrAdd(type, CreateWithCapacityActivator);
         
         private static Func<object> CreateActivator(Type type)
         {

--- a/src/Binaron.Serializer/Extensions/TypeExtensions.cs
+++ b/src/Binaron.Serializer/Extensions/TypeExtensions.cs
@@ -36,10 +36,18 @@ namespace Binaron.Serializer.Extensions
             
             return type == typeof(Guid) ? TypeCode.Guid : TypeCode.Object;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Type UnwrapNullable(this Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType == null ? type : underlyingType;
+        }
     }
 
     internal static class TypeOf<T>
     {
         public static readonly TypeCode TypeCode = typeof(T).GetTypeCode();
+        public static readonly TypeCode NullableUnwrappedTypeCode = typeof(T).UnwrapNullable().GetTypeCode();
     }
 }

--- a/src/Binaron.Serializer/Infrastructure/EnumerableWrapperWithAdd.cs
+++ b/src/Binaron.Serializer/Infrastructure/EnumerableWrapperWithAdd.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace Binaron.Serializer.Infrastructure
+{
+    internal static class EnumerableWrapperWithAdd
+    {
+        public static readonly ConcurrentDictionary<Type, object> Adders = new ConcurrentDictionary<Type, object>();
+    }
+    
+    internal readonly struct EnumerableWrapperWithAdd<T>
+    {
+        private readonly Action<object, T> action;
+        private readonly object result;
+
+        public bool HasAddAction => action != null;
+
+        public EnumerableWrapperWithAdd(IEnumerable<T> result) : this()
+        {
+            action = (Action<object, T>) EnumerableWrapperWithAdd.Adders.GetOrAdd(result.GetType(), CreateAdder);
+            this.result = result;
+        }
+
+        private static object CreateAdder(Type type)
+        {
+            var method = type.GetMethod("Add", new[] {typeof(T)});
+
+            if (method == null)
+                return null;
+
+            var dynamicMethod = new DynamicMethod(Guid.NewGuid().ToString(), null, new[] {typeof(object), typeof(T)});
+
+            var il = dynamicMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(method.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, method);
+            il.Emit(OpCodes.Ret);
+
+            return dynamicMethod.CreateDelegate(typeof(Action<object, T>));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(T value) => action(result, value);
+    }
+}

--- a/src/Binaron.Serializer/Infrastructure/GenericReader.cs
+++ b/src/Binaron.Serializer/Infrastructure/GenericReader.cs
@@ -13,7 +13,7 @@ namespace Binaron.Serializer.Infrastructure
     {
         private static readonly ConcurrentDictionary<(Type KeyType, Type ValueType), Func<ReaderState, object, int, (bool Success, object Result)>> DictionaryAdders = new ConcurrentDictionary<(Type KeyType, Type ValueType), Func<ReaderState, object, int, (bool Success, object Result)>>();
         private static readonly ConcurrentDictionary<Type, Func<ReaderState, object, (bool Success, object Result)>> ObjectAsDictionaryAdders = new ConcurrentDictionary<Type, Func<ReaderState, object, (bool Success, object Result)>>();
-        private static readonly ConcurrentDictionary<(Type ParentType, (Type KeyType, Type ValueType)), GenericResultObjectCreator.Dictionary> DictionaryResultObjectCreators = new ConcurrentDictionary<(Type ParentType, (Type KeyType, Type ValueType)), GenericResultObjectCreator.Dictionary>();
+        private static readonly ConcurrentDictionary<(Type ParentType, (Type KeyType, Type ValueType) Type), GenericResultObjectCreator.Dictionary> DictionaryResultObjectCreators = new ConcurrentDictionary<(Type ParentType, (Type KeyType, Type ValueType) Type), GenericResultObjectCreator.Dictionary>();
 
         public static object ReadEnums<T, TElement>(ReaderState reader)
         {
@@ -59,6 +59,22 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<TElement> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<TElement>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                w.Add((TElement) v);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -84,6 +100,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<bool> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<bool>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Bool)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadBool(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -113,6 +154,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<byte> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<byte>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Byte)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadByte(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -138,6 +204,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<char> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<char>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Char)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadChar(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -167,6 +258,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<DateTime> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<DateTime>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.DateTime)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadDateTime(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -192,6 +308,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<Guid> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<Guid>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Guid)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadGuid(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -221,6 +362,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<decimal> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<decimal>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Decimal)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadDecimal(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -246,6 +412,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<double> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<double>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Double)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadDouble(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -275,6 +466,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<short> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<short>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Short)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadShort(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -300,6 +516,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<int> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<int>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Int)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadInt(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -329,6 +570,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<long> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<long>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Long)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadLong(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -354,6 +620,31 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<sbyte> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<sbyte>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.SByte)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadSByte(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -383,6 +674,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<float> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<float>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.Float)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadFloat(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -407,6 +723,30 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<string> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<string>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.String)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadString(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                    w.Add(v);
+                                }
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -436,6 +776,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<ushort> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<ushort>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UShort)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadUShort(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -463,6 +828,31 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<uint> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<uint>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.UInt)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadUInt(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -488,7 +878,34 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+
                     }
+
+                    if (result is IEnumerable<ulong> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<ulong>(e);
+                        if (w.HasAddAction)
+                        {
+                            var valueType = Reader.ReadSerializedType(reader);
+                            if (valueType == SerializedType.ULong)
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                    w.Add(Reader.ReadULong(reader));
+                            }
+                            else
+                            {
+                                while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                                {
+                                    var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                    if (v.HasValue)
+                                        w.Add(v.Value);
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+
 
                     Discarder.Discard(reader);
                     return result;
@@ -517,6 +934,22 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<TElement> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<TElement>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsObject<TElement>(reader, valueType);
+                                w.Add((TElement) v);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -534,6 +967,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<bool> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<bool>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsBool(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -555,6 +1005,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<byte> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<byte>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsByte(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -572,6 +1039,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<char> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<char>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsChar(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -593,6 +1077,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<DateTime> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<DateTime>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDateTime(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -610,6 +1111,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<Guid> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<Guid>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsGuid(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -631,6 +1149,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<decimal> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<decimal>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDecimal(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -648,6 +1183,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<double> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<double>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsDouble(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -669,6 +1221,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<short> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<short>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsShort(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -686,6 +1255,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<int> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<int>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsInt(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -707,6 +1293,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<long> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<long>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsLong(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -724,6 +1327,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<sbyte> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<sbyte>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsSByte(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -745,6 +1365,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<float> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<float>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsFloat(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -761,6 +1398,22 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<string> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<string>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsString(reader, valueType);
+                                w.Add(v);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -782,6 +1435,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<ushort> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<ushort>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsUShort(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -801,6 +1471,23 @@ namespace Binaron.Serializer.Infrastructure
                         return typeof(T).IsArray ? ToArray(l) : result;
                     }
 
+                    if (result is IEnumerable<uint> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<uint>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsUInt(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
+                    }
+
                     Discarder.Discard(reader);
                     return result;
                 }
@@ -818,6 +1505,23 @@ namespace Binaron.Serializer.Infrastructure
                         }
 
                         return typeof(T).IsArray ? ToArray(l) : result;
+                    }
+
+                    if (result is IEnumerable<ulong> e)
+                    {
+                        var w = new EnumerableWrapperWithAdd<ulong>(e);
+                        if (w.HasAddAction)
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var valueType = Reader.ReadSerializedType(reader);
+                                var v = SelfUpgradingReader.ReadAsULong(reader, valueType);
+                                if (v.HasValue)
+                                    w.Add(v.Value);
+                            }
+
+                            return result;
+                        }
                     }
 
                     Discarder.Discard(reader);
@@ -922,8 +1626,36 @@ namespace Binaron.Serializer.Infrastructure
         {
             public static (bool Success, object Result) AddEnums<T>(ReaderState reader, object list, bool convertToArray) where T : struct
             {
-                if (!(list is ICollection<T> l)) 
-                    return (false, list);
+                if (!(list is ICollection<T> l))
+                {
+                    if (!(list is IEnumerable<T> e))
+                        return (false, list);
+
+                    var adder = new EnumerableWrapperWithAdd<T>(e);
+                    if (!adder.HasAddAction)
+                        return (false, list);
+
+                    do
+                    {
+                        try
+                        {
+                            while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                            {
+                                var val = ReadEnum<T>(reader);
+                                if (val.HasValue)
+                                    adder.Add(val.Value);
+                            }
+                            break;
+                        }
+                        catch (InvalidCastException)
+                        {
+                        }
+                        catch (OverflowException)
+                        {
+                        }
+                    } while (true);
+                    return (true, list);
+                }
 
                 do
                 {
@@ -1922,9 +2654,9 @@ namespace Binaron.Serializer.Infrastructure
             return result;
         }
 
-        private static Func<ReaderState, object, (bool Success, object Result)> GetObjectAsDictionaryAdder(Type type) => ObjectAsDictionaryAdders.GetOrAdd(type, _ =>
+        private static Func<ReaderState, object, (bool Success, object Result)> GetObjectAsDictionaryAdder(Type type) => ObjectAsDictionaryAdders.GetOrAdd(type, t =>
         {
-            var method = typeof(ObjectAsDictionaryAdder).GetMethod(nameof(ObjectAsDictionaryAdder.AddAll))?.MakeGenericMethod(type) ?? throw new MissingMethodException();
+            var method = typeof(ObjectAsDictionaryAdder).GetMethod(nameof(ObjectAsDictionaryAdder.AddAll))?.MakeGenericMethod(t) ?? throw new MissingMethodException();
             return (Func<ReaderState, object, (bool Success, object Result)>) Delegate.CreateDelegate(typeof(Func<ReaderState, object, (bool Success, object Result)>), null, method);
         });
 
@@ -1982,9 +2714,9 @@ namespace Binaron.Serializer.Infrastructure
             return result;
         }
         
-        private static Func<ReaderState, object, int, (bool Success, object Result)> GetDictionaryAdder((Type KeyType, Type ValueType) type) => DictionaryAdders.GetOrAdd(type, _ =>
+        private static Func<ReaderState, object, int, (bool Success, object Result)> GetDictionaryAdder((Type KeyType, Type ValueType) type) => DictionaryAdders.GetOrAdd(type, t =>
         {
-            var method = typeof(DictionaryAdder).GetMethod(nameof(DictionaryAdder.AddAll))?.MakeGenericMethod(type.KeyType, type.ValueType) ?? throw new MissingMethodException();
+            var method = typeof(DictionaryAdder).GetMethod(nameof(DictionaryAdder.AddAll))?.MakeGenericMethod(t.KeyType, t.ValueType) ?? throw new MissingMethodException();
             return (Func<ReaderState, object, int, (bool Success, object Result)>) Delegate.CreateDelegate(typeof(Func<ReaderState, object, int, (bool Success, object Result)>), null, method);
         });
 
@@ -2031,7 +2763,7 @@ namespace Binaron.Serializer.Infrastructure
         }
         
         private static GenericResultObjectCreator.Dictionary GetDictionaryResultObjectCreator(Type parentType, (Type KeyType, Type ValueType) type) => 
-            DictionaryResultObjectCreators.GetOrAdd((parentType, type), _ => new GenericResultObjectCreator.Dictionary(parentType, type));
+            DictionaryResultObjectCreators.GetOrAdd((parentType, type), tuple => new GenericResultObjectCreator.Dictionary(tuple.ParentType, tuple.Type));
 
         private static object CreateResultObject(Type parentType, (Type KeyType, Type ValueType) type, int count) => GetDictionaryResultObjectCreator(parentType, type).Create(ListCapacity.Clamp(count));
         

--- a/src/Binaron.Serializer/Infrastructure/GenericType.cs
+++ b/src/Binaron.Serializer/Infrastructure/GenericType.cs
@@ -17,10 +17,10 @@ namespace Binaron.Serializer.Infrastructure
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (Type Type, Enums.TypeCode Code) GetICollection(Type listType) => CollectionGenericTypeLookup.GetOrAdd(listType,
-            _ =>
+            lt =>
             {
-                var type = listType.GetInterfaces().Concat(listType.Yield().Where(t => t.IsInterface))
-                    .FirstOrDefault(type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ICollection<>))?
+                var type = lt.GetInterfaces().Concat(lt.Yield().Where(t => t.IsInterface))
+                    .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(ICollection<>))?
                     .GenericTypeArguments[0];
                 return (type, type.GetTypeCode());
             });
@@ -32,10 +32,10 @@ namespace Binaron.Serializer.Infrastructure
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (Type Type, Enums.TypeCode Code) GetIEnumerable(Type enumerableType) => EnumerableGenericTypeLookup.GetOrAdd(enumerableType,
-            _ =>
+            et =>
             {
-                var type = enumerableType.GetInterfaces().Concat(enumerableType.Yield().Where(t => t.IsInterface))
-                    .FirstOrDefault(type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))?
+                var type = et.GetInterfaces().Concat(et.Yield().Where(t => t.IsInterface))
+                    .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>))?
                     .GenericTypeArguments[0];
                 return (type, type.GetTypeCode());
             });
@@ -46,7 +46,7 @@ namespace Binaron.Serializer.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (Type KeyType, Type ValueType) GetIReadOnlyDictionaryWriter(Type dictionaryType) => WriterReadOnlyDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, _ => GetIReadOnlyDictionary(dictionaryType));
+        public static (Type KeyType, Type ValueType) GetIReadOnlyDictionaryWriter(Type dictionaryType) => WriterReadOnlyDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, GetIReadOnlyDictionary);
 
         public static class GetIReadOnlyDictionaryWriterGenericTypes<T>
         {
@@ -54,7 +54,7 @@ namespace Binaron.Serializer.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (Type KeyType, Type ValueType) GetIDictionaryWriter(Type dictionaryType) => WriterDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, _ => GetIDictionary(dictionaryType));
+        public static (Type KeyType, Type ValueType) GetIDictionaryWriter(Type dictionaryType) => WriterDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, GetIDictionary);
 
         public static class GetIDictionaryWriterGenericTypes<T>
         {
@@ -62,7 +62,7 @@ namespace Binaron.Serializer.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (Type KeyType, Type ValueType) GetIDictionaryReader(Type dictionaryType) => ReaderDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, _ => GetIEnumerableKvp(dictionaryType));
+        public static (Type KeyType, Type ValueType) GetIDictionaryReader(Type dictionaryType) => ReaderDictionaryGenericTypeLookup.GetOrAdd(dictionaryType, GetIEnumerableKvp);
 
         private static (Type KeyType, Type ValueType) GetIDictionary(Type dictionaryType)
         {

--- a/src/Binaron.Serializer/Infrastructure/SelfUpgradingReader.cs
+++ b/src/Binaron.Serializer/Infrastructure/SelfUpgradingReader.cs
@@ -84,9 +84,10 @@ namespace Binaron.Serializer.Infrastructure
         }
 
         private static readonly ConcurrentDictionary<(Type, Type), Func<object, object>> Upgraders = new ConcurrentDictionary<(Type, Type), Func<object, object>>();
-        private static Func<object, object> GetUpgrader(Type from, Type to) => Upgraders.GetOrAdd((from, to), _ =>
+        private static Func<object, object> GetUpgrader(Type from, Type to) => Upgraders.GetOrAdd((from, to), tuple =>
         {
-            var method = typeof(Upgrader).GetMethod(nameof(Upgrader.Upgrade))?.MakeGenericMethod(from, to) ?? throw new MissingMethodException();
+            var (f, t) = tuple;
+            var method = typeof(Upgrader).GetMethod(nameof(Upgrader.Upgrade))?.MakeGenericMethod(f, t) ?? throw new MissingMethodException();
             return (Func<object, object>) Delegate.CreateDelegate(typeof(Func<object, object>), null, method);
         });
 

--- a/src/Binaron.Serializer/Serializer.cs
+++ b/src/Binaron.Serializer/Serializer.cs
@@ -210,8 +210,8 @@ namespace Binaron.Serializer
                 return;
 
             // fallback to non-generic version (we are not enumerating twice)
-            // ReSharper disable once PossibleMultipleEnumeration
             writer.Write((byte) SerializedType.Enumerable);
+            // ReSharper disable once PossibleMultipleEnumeration
             WriteEnumerableFallback(writer, enumerable);
         }
 
@@ -223,8 +223,8 @@ namespace Binaron.Serializer
                 return;
 
             // fallback to non-generic version (we are not enumerating twice)
-            // ReSharper disable once PossibleMultipleEnumeration
             writer.Write((byte) SerializedType.Enumerable);
+            // ReSharper disable once PossibleMultipleEnumeration
             WriteEnumerableFallback(writer, enumerable);
         }
 
@@ -243,13 +243,71 @@ namespace Binaron.Serializer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WritePrimitive(WriterState writer, object value)
         {
-            return WritePrimitive(writer, value.GetType().GetTypeCode(), value);
+            return WritePrimitive(writer, value.GetType().UnwrapNullable().GetTypeCode(), value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WritePrimitive<T>(WriterState writer, T value)
         {
-            return WritePrimitive(writer, TypeOf<T>.TypeCode, value);
+            return WritePrimitive(writer, TypeOf<T>.NullableUnwrappedTypeCode, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WritePrimitive(WriterState writer, TypeCode typeCode, object value)
+        {
+            switch (typeCode)
+            {
+                case TypeCode.String:
+                    Writer.Write(writer, (string) value);
+                    return true;
+                case TypeCode.UInt32:
+                    Writer.Write(writer, (uint) value);
+                    return true;
+                case TypeCode.Int32:
+                    Writer.Write(writer, (int) value);
+                    return true;
+                case TypeCode.Byte:
+                    Writer.Write(writer, (byte) value);
+                    return true;
+                case TypeCode.SByte:
+                    Writer.Write(writer, (sbyte) value);
+                    return true;
+                case TypeCode.UInt16:
+                    Writer.Write(writer, (ushort) value);
+                    return true;
+                case TypeCode.Int16:
+                    Writer.Write(writer, (short) value);
+                    return true;
+                case TypeCode.Int64:
+                    Writer.Write(writer, (long) value);
+                    return true;
+                case TypeCode.UInt64:
+                    Writer.Write(writer, (ulong) value);
+                    return true;
+                case TypeCode.Single:
+                    Writer.Write(writer, (float) value);
+                    return true;
+                case TypeCode.Double:
+                    Writer.Write(writer, (double) value);
+                    return true;
+                case TypeCode.Decimal:
+                    Writer.Write(writer, (decimal) value);
+                    return true;
+                case TypeCode.Boolean:
+                    Writer.Write(writer, (bool) value);
+                    return true;
+                case TypeCode.DateTime:
+                    Writer.Write(writer, (DateTime) value);
+                    return true;
+                case TypeCode.Guid:
+                    Writer.Write(writer, (Guid) value);
+                    return true;
+                case TypeCode.Char:
+                    Writer.Write(writer, (char) value);
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
* - add support of IEnumerable with Add method (i.e. implementation enough for var x = new T() { e1, e2, e3 } syntax.
- add debug code

* - refactor the method of restoring IEnumerable with Add method (#31)
- support of nullable in collections and as properties (#34, #35, #36)

Co-authored-by: Nikolay Gekht <nikolay.gekht@gehtsoftusa.com>