### PR TITLE
Fix for #32 (#7)

### DIFF
--- a/src/Binaron.Serializer.Tests/ReadOnlySerializationTest.cs
+++ b/src/Binaron.Serializer.Tests/ReadOnlySerializationTest.cs
@@ -1,0 +1,213 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Binaron.Serializer.Tests
+{
+    class ReadOnlySerializationTest
+    {
+
+        [Test]
+        public void ReadOnlyStructTest()
+        {
+            ReadOnlyStruct rsu = new ReadOnlyStruct(1, "text");
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(rsu, stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            dynamic rsu1 = BinaronConvert.Deserialize(stream);
+            Assert.AreEqual(rsu.IntValue, rsu1.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu1.StringValue);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var rsu2 = BinaronConvert.Deserialize<ReadOnlyStruct>(stream);
+
+            //reproduce issue https://github.com/zachsaw/Binaron.Serializer/issues/32
+            Assert.AreEqual(rsu.IntValue, rsu1.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu1.StringValue);
+
+        }
+
+        [Test]
+        public void ReadOnlyClassTest_OnlyPrimitives()
+        {
+            ReadOnlyClass rsu = new ReadOnlyClass(1, "text");
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(rsu, stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            dynamic rsu1 = BinaronConvert.Deserialize(stream);
+            Assert.AreEqual(rsu.IntValue, rsu1.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu1.StringValue);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var rsu2 = BinaronConvert.Deserialize<ReadOnlyClass>(stream);
+
+            //reproduce issue https://github.com/zachsaw/Binaron.Serializer/issues/32
+            Assert.AreEqual(rsu.IntValue, rsu2.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu2.StringValue);
+            Assert.IsNull(rsu2.Aggregate);
+        }
+
+        [Test]
+        public void ReadOnlyClassTest_ClassProperty()
+        {
+            ReadOnlyClass rsu = new ReadOnlyClass(1, "text", new ReadOnlyStruct(2, "subtext"));
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(rsu, stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            dynamic rsu1 = BinaronConvert.Deserialize(stream);
+            Assert.AreEqual(rsu.IntValue, rsu1.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu1.StringValue);
+            Assert.AreEqual(rsu.Aggregate.Value.IntValue, rsu1.Aggregate.IntValue);
+            Assert.AreEqual(rsu.Aggregate.Value.StringValue, rsu1.Aggregate.StringValue);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var rsu2 = BinaronConvert.Deserialize<ReadOnlyClass>(stream);
+
+            //reproduce issue https://github.com/zachsaw/Binaron.Serializer/issues/32
+            Assert.AreEqual(rsu.IntValue, rsu2.IntValue);
+            Assert.AreEqual(rsu.StringValue, rsu2.StringValue);
+            Assert.AreEqual(rsu.Aggregate.Value.IntValue, rsu2.Aggregate.Value.IntValue);
+            Assert.AreEqual(rsu.Aggregate.Value.StringValue, rsu2.Aggregate.Value.StringValue);
+
+        }
+
+        [Test]
+        public void ReadOnlyClassTest_TypeConversionToLessProperties()
+        {
+            ReadOnlyClass rsu = new ReadOnlyClass(1, "text", new ReadOnlyStruct(2, "subtext"));
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(rsu, stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var rsu2 = BinaronConvert.Deserialize<ReadOnlyClass1>(stream);
+
+            Assert.AreEqual(rsu.IntValue, rsu2.IntValue);
+            Assert.AreEqual(rsu.Aggregate.Value.IntValue, rsu2.Aggregate.IntValue);
+            Assert.AreEqual(rsu.Aggregate.Value.StringValue, rsu2.Aggregate.StringValue);
+            Assert.AreEqual(null, rsu2.Aggregate.Aggregate);
+        }
+        
+        [Test]
+        public void ReadOnlyClassTest_TypeConversionToMoreProperties()
+        {
+            ReadOnlyClass1 rsu = new ReadOnlyClass1(1, new ReadOnlyClass(2, "subtext"));
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(rsu, stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var rsu2 = BinaronConvert.Deserialize<ReadOnlyClass>(stream);
+
+            Assert.AreEqual(rsu.IntValue, rsu2.IntValue);
+            Assert.IsNull(rsu2.StringValue);
+
+            Assert.IsNotNull(rsu2.Aggregate);
+            Assert.AreEqual(rsu.Aggregate.IntValue, rsu2.Aggregate.Value.IntValue);
+            Assert.AreEqual(rsu.Aggregate.StringValue, rsu2.Aggregate.Value.StringValue);
+        }
+
+        [Test]
+        public void ListOfStruct()
+        {
+            List<ReadOnlyStruct> list = new List<ReadOnlyStruct>()
+            {
+                new ReadOnlyStruct(1, "text1"),
+                new ReadOnlyStruct(2, "text2"),
+                new ReadOnlyStruct(3, "text3"),
+            };
+
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(list, stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var list1 = BinaronConvert.Deserialize<List<ReadOnlyStruct>>(stream);
+            Assert.IsNotNull(list1);
+            Assert.AreEqual(3, list1.Count);
+
+            Assert.AreEqual(1, list1[0].IntValue);
+            Assert.AreEqual("text1", list1[0].StringValue);
+            Assert.AreEqual(2, list1[1].IntValue);
+            Assert.AreEqual("text2", list1[1].StringValue);
+            Assert.AreEqual(3, list1[2].IntValue);
+            Assert.AreEqual("text3", list1[2].StringValue);
+        }
+
+        [Test]
+        public void ArrayfClasses()
+        {
+            ReadOnlyClass[] list = new ReadOnlyClass[]
+            {
+                new ReadOnlyClass(1, "text1"),
+                new ReadOnlyClass(2, "text2"),
+                new ReadOnlyClass(3, "text3"),
+            };
+
+            using var stream = new MemoryStream();
+            BinaronConvert.Serialize(list, stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var list1 = BinaronConvert.Deserialize<ReadOnlyClass[]>(stream);
+            Assert.IsNotNull(list1);
+            Assert.AreEqual(3, list1.Length);
+
+            Assert.AreEqual(1, list1[0].IntValue);
+            Assert.AreEqual("text1", list1[0].StringValue);
+            Assert.AreEqual(2, list1[1].IntValue);
+            Assert.AreEqual("text2", list1[1].StringValue);
+            Assert.AreEqual(3, list1[2].IntValue);
+            Assert.AreEqual("text3", list1[2].StringValue);
+        }
+
+        private readonly struct ReadOnlyStruct
+        {
+            public int IntValue { get; }
+            public string StringValue { get; }
+
+            public ReadOnlyStruct(int intValue, string stringValue)
+            {
+                IntValue = intValue;
+                StringValue = stringValue;
+            }
+        }
+
+        private class ReadOnlyClass
+        {
+            public int IntValue { get; }
+            public string StringValue { get; }
+
+            public ReadOnlyStruct? Aggregate { get; }
+
+            public ReadOnlyClass(int intValue, string stringValue) : this(intValue, stringValue, null)
+            {
+            }
+
+            [JsonConstructor]
+            public ReadOnlyClass(int intValue, string stringValue, ReadOnlyStruct? aggregate)
+            {
+                IntValue = intValue;
+                StringValue = stringValue;
+                Aggregate = aggregate;
+            }
+        }
+
+        private class ReadOnlyClass1
+        {
+            public int IntValue { get; }
+
+            public ReadOnlyClass Aggregate { get; }
+
+            [BinaronConstructor]
+            public ReadOnlyClass1(int intValue, ReadOnlyClass aggregate)
+            {
+                IntValue = intValue;
+                Aggregate = aggregate;
+            }
+        }
+
+    }
+}

--- a/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
+++ b/src/Binaron.Serializer.Tests/ValueSerializationTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 using Binaron.Serializer.CustomObject;
 using Binaron.Serializer.Tests.Extensions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Binaron.Serializer/BinaronConstructorAttribute.cs
+++ b/src/Binaron.Serializer/BinaronConstructorAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Binaron.Serializer
+{
+    [AttributeUsage(AttributeTargets.Constructor)]
+    public class BinaronConstructorAttribute : Attribute
+    {
+        public BinaronConstructorAttribute()
+        {
+
+        }
+    }
+}

--- a/src/Binaron.Serializer/TypedDeserializer.cs
+++ b/src/Binaron.Serializer/TypedDeserializer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Binaron.Serializer.Accessors;
 using Binaron.Serializer.Creators;
@@ -282,7 +284,216 @@ namespace Binaron.Serializer
                 if (typeof(IDictionary).IsAssignableFrom(typeInfo.ActualType))
                     return new DictionaryReader(type, typeInfo.Activate);
 
+                //if it is a structure and has read-only attribute
+                if (typeInfo.ActualType.IsValueType && typeInfo.ActualType.GetCustomAttribute<IsReadOnlyAttribute>() != null)
+                    return new ReadOnlyReader(typeInfo.ActualType);
+
+                //if object has no default constructor && has a constructor marked with JsonDeserializer
+                if (!typeInfo.ActualType.IsValueType && typeInfo.ActualType.GetConstructor(Array.Empty<Type>()) == null)
+                {
+                    var constructors = type.GetConstructors();
+                    ConstructorInfo jsonConstuctor = null, binaronConstructor = null;
+                    foreach (var constructor in constructors)
+                    {
+                        foreach (var attribute in constructor.GetCustomAttributes())
+                        {
+                            if (attribute is BinaronConstructorAttribute)
+                                binaronConstructor = constructor;
+                            if (attribute.GetType().Name.EndsWith("JsonConstructorAttribute"))
+                                jsonConstuctor = constructor;
+                        }
+                    }
+                    var constructor1 = binaronConstructor ?? jsonConstuctor;
+                    if (constructor1 != null)
+                        return new ReadOnlyReader(typeInfo.ActualType, constructor1);
+                }
+
                 return new ObjectReader(type, typeInfo.Activate, typeInfo.Setters);
+            }
+
+            private class ReadOnlyReader : IObjectReader
+            {
+                class ElementInformation
+                {
+                    public Type TargetType { get; }
+                    public Func<ReaderState, object> Reader { get; }
+                    public int ParameterPosition { get; }
+
+                    public ElementInformation(Type type, Func<ReaderState, object> reader, int parameterPosition)
+                    {
+                        this.TargetType = type;
+                        this.Reader = reader;
+                        this.ParameterPosition = parameterPosition;
+                    }
+                }
+
+                private readonly Type Type;
+                private readonly Dictionary<string, ElementInformation> PropertiesInfo = new Dictionary<string, ElementInformation>();
+                private readonly ConstructorInfo Constructor;
+                private readonly int ConstructorParametersCount;
+
+                public ReadOnlyReader(Type type) : this(type, null)
+                {
+
+                }
+
+                public ReadOnlyReader(Type type, ConstructorInfo constructor)
+                {
+                    var properties = new List<(string name, Type target)>();
+
+                    this.Type = type;
+                    foreach (var property in type.GetProperties())
+                        properties.Add((property.Name, property.PropertyType));
+
+                    foreach (var field in type.GetFields())
+                        properties.Add((field.Name, field.FieldType));
+
+                    if (constructor == null)
+                    {
+                        constructor = FindBestMatch(type, properties);
+                        if (constructor == null)
+                            throw new ArgumentException($"The constructor with the parameters that matches at least one of the properties is not found in the type {type.FullName}", nameof(type));
+                    }
+
+                    Constructor = constructor;
+
+
+                    var parameters = constructor.GetParameters();
+                    ConstructorParametersCount = parameters.Length;
+
+                    //find position of the parameter in the best
+                    //matching constructor and create a dictionary entry
+                    for (int i = 0; i < properties.Count; i++)
+                    {
+                        int parameterPosition = -1;
+                        for (int j = 0; j < ConstructorParametersCount; j++)
+                        {
+                            if (string.Compare(properties[i].name, parameters[j].Name, true) == 0)
+                            {
+                                parameterPosition = i;
+                                break;
+                            }
+                        }
+                        PropertiesInfo.Add(properties[i].name, new ElementInformation(properties[i].target, CreateReader(properties[i].target), parameterPosition));
+                    }
+                }
+            
+
+                // Finds a constructor which has the maximum number
+                private static ConstructorInfo FindBestMatch(Type type, List<(string name, Type target)> properties)
+                {
+                    ConstructorInfo[] constructors = type.GetConstructors();
+                    int[] scores = new int[constructors.Length];
+
+                    for (int i = 0; i < scores.Length; i++)
+                        scores[i] = 0;
+
+                    //add a score for a constructor when the property/field is 
+                    //found among the parameters
+                    foreach (var property in properties)
+                    {
+                        for (int i = 0; i < constructors.Length; i++)
+                        {
+                            var parameters = constructors[i].GetParameters();
+                            for (int j = 0; j < parameters.Length; j++)
+                            {
+                                if (string.Compare(parameters[j].Name, property.name, true) == 0)
+                                {
+                                    scores[i]++;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    ConstructorInfo bestMatching = null, jsonConstructor = null, binaronConstructor = null;
+                    int bestMatchingScore = 0;
+
+                    for (int i = 0; i < scores.Length; i++)
+                    {
+                        if (constructors[i].GetCustomAttributes().Any(attribute => attribute.GetType().Name.EndsWith("JsonConstructorAttribute")))
+                            jsonConstructor = constructors[i];
+
+                        if (constructors[i].GetCustomAttribute<BinaronConstructorAttribute>() != null)
+                            binaronConstructor = constructors[i];
+
+                        if (scores[i] > bestMatchingScore)
+                        {
+                            bestMatchingScore = scores[i];
+                            bestMatching = constructors[i];
+                        }
+                    }
+
+                    return (binaronConstructor ?? jsonConstructor) ?? bestMatching;
+                }
+
+                public object Read(ReaderState reader)
+                {
+                    object[] constructorParameters = new object[ConstructorParametersCount];
+
+                    while (Reader.ReadEnumerableType(reader) == EnumerableType.HasItem)
+                    {
+                        object obj = null;
+                        var key = reader.ReadString();
+                        if (PropertiesInfo.TryGetValue(key, out ElementInformation elementInfo))
+                        {
+                            obj = elementInfo.Reader(reader);
+                            if (obj == null || obj.GetType() != elementInfo.TargetType)
+                                obj = Convert(obj, elementInfo.TargetType);
+                            if (elementInfo.ParameterPosition >= 0)
+                                constructorParameters[elementInfo.ParameterPosition] = obj;
+                        }
+                        else
+                            Discarder.DiscardValue(reader);
+                    }
+                    return Constructor.Invoke(constructorParameters);
+                }
+
+                private static Func<ReaderState, object> CreateReader(Type type)
+                {
+                    object defaultObject = null;
+                    MethodInfo readValueGenericMethod = typeof(TypedDeserializer).GetMethod(nameof(TypedDeserializer.ReadValue), new Type[] { typeof(ReaderState), typeof(SerializedType) });
+                    MethodInfo readValueMethod = readValueGenericMethod.MakeGenericMethod(new Type[] { type });
+
+                    if (type.IsValueType)
+                        defaultObject = Activator.CreateInstance(type);
+
+                    return (reader) =>
+                    {
+                        var valueType = Reader.ReadSerializedType(reader);
+                        return valueType != SerializedType.Null ? readValueMethod.Invoke(null, new object[] { reader, valueType }) : defaultObject;
+
+                    };
+                }
+
+                private static object Convert(object src, Type target)
+                {
+                    if (src == null)
+                    {
+                        if (target.IsValueType)
+                            return Activator.CreateInstance(target);
+                        return src;
+                    }
+
+                    Type sourceType = src.GetType();
+
+                    var target1 = Nullable.GetUnderlyingType(target);
+                    if (target1 != null && target1 != target)
+                        target = target1;
+
+                    if (src.GetType() == target)
+                        return src; 
+
+                    if (target.IsEnum)
+                    {
+                        if (src is string s)
+                            return Enum.Parse(target, s);
+                        else
+                            return Enum.ToObject(target, src);
+                    }
+
+                    return System.Convert.ChangeType(src, target);
+                }
             }
 
             private class ObjectReader : IObjectReader


### PR DESCRIPTION
Commit Description:

For read-only structures, the library is looking for a constructor, parameters of which has the best match with the structure properties.

For classes with no default constructor, it looks for the constructor attributed by BinaronConstructorAttribute or JsonConstructorAttribute and matches constructor parameters with serialized properties by the name.

New code is covered with the tests

Notes: 

Fix for zachsaw#32

Problem Summary:

* The library wasn't able to restore read-only structures (it created structures with default(T) values in properties)

* The library wasn't able to restore classes with no default constructor (exception raised)

Summary of changes:

A new `TypedDeserializer.ReadOnlyReader` is added to restore read-only structures and classes. 

The `TypedDeserealized.CreateReader` method is adjusted to detect read-only classes and structures with minimal effect on performance. 

For read-only structures, the library is looking for a constructor, parameters of which has the best match with the structure properties.

For classes with no default constructor, it looks for the constructor attributed by `BinaronConstructorAttribute` or `JsonConstructorAttribute` and matches constructor parameters with serialized properties by the name. `BinaronConstructorAttribute` has priority over `JsonConstructorAttribute` (e.g. the latter one will be used only in case the first one is not defined).

Note 1: Reasoning to use the attribute approach for classes. The first version I implemented I've been looking for the best matching constructor any time when the default constructor is not defined, but it interfered with the existing tests (where `ITestBase` interface is involved. Resolving the conflict wasn't possible without slowing down the default scenarios, as it would involve an additional heuristic for all classes. So, I decided to limit this scenario only for the classes that:

* Has no defined default constructor.
* And has constructor attributed.

This way the default scenario performance remains unaffected.

Note 2: Using of `JsonConstructorAttribute` does not create a dependency on the Json package, it is checked by the type name.
